### PR TITLE
MSAPI-409 Admin Support for VersionFields

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ import os
 
 setup(
     name = "django-versionfield",
-    version = "0.3",
+    version = "0.3.1",
     url = 'https://github.com/mindsnacks/django-versionfield',
     license = 'BSD',
     description = "A DB Independent Custom Django Field for storing Version numbers for fast indexing",

--- a/versionfield/__init__.py
+++ b/versionfield/__init__.py
@@ -20,7 +20,7 @@ class VersionField(models.PositiveIntegerField):
 
 	def to_python(self,value):
 		if isinstance(value, Version):
-			return Version
+			return value
 
 		if isinstance(value,basestring):
 			return Version(value,self.number_bits)

--- a/versionfield/__init__.py
+++ b/versionfield/__init__.py
@@ -2,6 +2,8 @@ from django.db import models
 from .constants import DEFAULT_NUMBER_BITS
 from .version import Version
 from utils import convert_version_string_to_int, convert_version_int_to_string
+import forms
+
 
 class VersionField(models.PositiveIntegerField):
 	"""
@@ -36,6 +38,14 @@ class VersionField(models.PositiveIntegerField):
 			return None
 
 		return int(value)
+
+	def formfield(self, **kwargs):
+		defaults = {
+			'form_class': forms.VersionField,
+			'number_bits': self.number_bits
+		}
+		defaults.update(kwargs)
+		return super(VersionField, self).formfield(**defaults)
 
 	def __unicode__(self, value):
 		return unicode(value)

--- a/versionfield/forms.py
+++ b/versionfield/forms.py
@@ -1,0 +1,21 @@
+from django import forms
+from version import Version
+from constants import DEFAULT_NUMBER_BITS
+from utils import convert_version_string_to_int
+
+class VersionField(forms.IntegerField):
+	def __init__(self,number_bits=DEFAULT_NUMBER_BITS,**kwargs):
+		self.number_bits = number_bits
+		return super(VersionField, self).__init__(**kwargs)
+
+	def to_python(self,value):
+		"""
+		Verifies that value can be converted to a Version object
+		"""
+		if isinstance(value,basestring):
+			return Version(value,self.number_bits)
+
+		if value is None:
+			return None
+
+		return Version(convert_version_int_to_string(value,self.number_bits),self.number_bits)


### PR DESCRIPTION
Needed to do a custom form field because the validation on IntegerField (super class) was throwing errors when you tried to pass in a string.

forms.VersionField subclasses django.forms.IntegerField and overrides to_python to verify that the value passed in from admin can be converted to a Version object
